### PR TITLE
channelz: make build script more forgiving when files not present

### DIFF
--- a/grpc-zpages/buildscripts/update_angular.sh
+++ b/grpc-zpages/buildscripts/update_angular.sh
@@ -7,6 +7,6 @@ cd $GRPC_ZPAGES_DIR/web/channelzui/
 npm install
 ng build --prod --build-optimizer --base-href=/dist_channelz/
 
-rm $GRPC_ZPAGES_DIR/cli/dist_channelz/*
-cp $GRPC_ZPAGES_DIR/web/channelzui/dist/* $GRPC_ZPAGES_DIR/cli/dist_channelz/
-
+rm -rf $GRPC_ZPAGES_DIR/cli/dist_channelz/
+mkdir -p $GRPC_ZPAGES_DIR/cli/dist_channelz/
+cp -r $GRPC_ZPAGES_DIR/web/channelzui/dist/* $GRPC_ZPAGES_DIR/cli/dist_channelz/


### PR DESCRIPTION
Because we use `set -e`, these commands will fail the script when
run for the first time. Use more forgiving versions of the
commands to avoid nonzero status.