### PR TITLE
channelz: add code gen scripts for OSS

### DIFF
--- a/grpc-zpages/buildscripts/channelz_codgen.sh
+++ b/grpc-zpages/buildscripts/channelz_codgen.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eu -o pipefail
+
+readonly GRPC_ZPAGES_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+readonly GRPC_WEB_DIR="$GRPC_ZPAGES_DIR"/buildscripts/github/grpc-web
+
+if [[ ! -d "$GRPC_WEB_DIR" ]]; then
+  mkdir -p "$GRPC_ZPAGES_DIR"/buildscripts/github
+  cd "$GRPC_ZPAGES_DIR"/buildscripts/github
+  git clone https://github.com/grpc/grpc-web.git
+  cd "$GRPC_WEB_DIR"
+  # Check out a known good SHA for reproducibility
+  git checkout 6357fa78f36d2e08636612f281250b31f28ae6ec
+fi
+
+cd "$GRPC_WEB_DIR"/net/grpc/gateway/docker
+docker build -t channelz_grpc_web_prereqs ./prereqs/
+
+cd "$GRPC_ZPAGES_DIR"/docker
+docker build -t channelz_codegen codegen
+
+docker run --rm   -v "$GRPC_ZPAGES_DIR"/docker/codegen/shared_dir:/shared_dir/ channelz_codegen /shared_dir/scripts/gen_channelz_pb.sh
+
+mv "$GRPC_ZPAGES_DIR"/docker/codegen/shared_dir/gen_out/channelz.js "$GRPC_ZPAGES_DIR"/web/channelzui/src/assets/channelz.js

--- a/grpc-zpages/docker/codegen/Dockerfile
+++ b/grpc-zpages/docker/codegen/Dockerfile
@@ -1,0 +1,10 @@
+FROM channelz_grpc_web_prereqs:latest
+
+RUN cd /github/grpc-web/javascript/net/grpc/web/ && make
+
+RUN cd /github/grpc-web && \
+  curl http://dl.google.com/closure-compiler/compiler-latest.zip \
+  -o compiler-latest.zip && \
+  rm -f closure-compiler.jar && \
+  unzip -p -qq -o compiler-latest.zip *.jar > closure-compiler.jar
+

--- a/grpc-zpages/docker/codegen/shared_dir/scripts/gen_channelz_pb.sh
+++ b/grpc-zpages/docker/codegen/shared_dir/scripts/gen_channelz_pb.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eu -o pipefail
+
+readonly SHARED_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+
+mkdir -p /github
+cd /github/
+git clone https://github.com/grpc/grpc-proto.git
+cd /github/grpc-proto
+git checkout 91d19ac45f696816df5f1547cacaa201280cdc68
+
+mkdir -p /workspace/
+
+# Run protoc and generate .js for msg types
+protoc -I=/github/grpc-proto/grpc/channelz/v1/ --js_out=import_style=closure,binary:/workspace channelz.proto
+protoc -I=/github/grpc-web/third_party/grpc/third_party/protobuf/src/ --js_out=import_style=closure,binary:/workspace google/protobuf/any.proto google/protobuf/duration.proto google/protobuf/timestamp.proto google/protobuf/wrappers.proto
+
+# Run protoc with grpc-web plugin to generate client
+protoc -I=/github/grpc-proto/grpc/channelz/v1/ --plugin=protoc-gen-grpc-web=/github/grpc-web/javascript/net/grpc/web/protoc-gen-grpc-web  --grpc-web_out=out=channelz.grpc.pb.js,mode=grpcweb:/workspace channelz.proto
+
+# Run closure compiler to produce a self contained .js file 
+mkdir -p "$SHARED_DIR"/gen_out/
+java \
+  -jar /github/grpc-web//closure-compiler.jar \
+  --js /workspace \
+  --js /github/grpc-web//javascript \
+  --js /github/grpc-web//net \
+  --js /github/grpc-web//third_party/closure-library \
+  --js /github/grpc-web//third_party/grpc/third_party/protobuf/js \
+  --entry_point=goog:proto.grpc.channelz.v1.ChannelzClient \
+  --entry_point=goog:proto.grpc.channelz.v1.SocketOptionTimeout \
+  --entry_point=goog:proto.grpc.channelz.v1.SocketOptionLinger \
+  --entry_point=goog:proto.grpc.channelz.v1.SocketOptionTcpInfo \
+  --dependency_mode=STRICT \
+  --js_output_file "$SHARED_DIR"/gen_out/channelz.js


### PR DESCRIPTION
Builds a self contained `channelz.js` from a `channelz.proto`.

Running `buildscripts/channelz_codgen.sh` will produce a
`web/channelzui/src/assets/channelz.js` that reflects the latest proto
from the `grpc/grpc-protos` repo.

The script fetches grpc/grpc-web to get the prereq docker image, does
some additional setup, and then runs the code gen script.