### PR TITLE
gprc-zpages: do not output uglified js when building

### DIFF
--- a/grpc-zpages/buildscripts/update_angular.sh
+++ b/grpc-zpages/buildscripts/update_angular.sh
@@ -13,5 +13,4 @@ if [[ $(which ng) == "" ]]; then
   exit 1
 fi
 
-ng build --prod --build-optimizer --base-href=/dist_channelz/
-
+ng build --base-href=/dist_channelz/


### PR DESCRIPTION
This makes the output easier to use, and there's not a real need for
uglified js in this tool. This also eliminates the hash appended to
the output filenames.