### PR TITLE
gdebug: fix start_docker.sh for osx

### DIFF
--- a/gdebug/docker/start_docker.sh
+++ b/gdebug/docker/start_docker.sh
@@ -17,7 +17,7 @@ readonly GRPC_ADDR=$2
 readonly GRPC_PORT=$3
 readonly ASSETS_PORT="8080"
 
-CONFIG="version: '2'
+readonly CONFIG="version: '2'
 services:
   front-envoy:
     build:

--- a/gdebug/docker/start_docker.sh
+++ b/gdebug/docker/start_docker.sh
@@ -23,8 +23,7 @@ readonly GRPC_ADDR=$2
 readonly GRPC_PORT=$3
 readonly ASSETS_PORT="8080"
 
-cat > "$TEMP" <<TERMINATOR
-version: '2'
+CONFIG="version: '2'
 services:
   front-envoy:
     build:
@@ -32,7 +31,7 @@ services:
       dockerfile: Dockerfile
     ports:
       # Forward host port to docker
-      - "$ENVOY_PORT:$ENVOY_PORT"
+      - '$ENVOY_PORT:$ENVOY_PORT'
     environment:
       - GRPC_HOST=$GRPC_ADDR
       - GRPC_PORT=$GRPC_PORT
@@ -42,7 +41,7 @@ services:
       - ASSETS_HOST=127.0.0.1
       - ASSETS_PORT=$ASSETS_PORT
     mem_limit: 1000000000
-    network_mode: "host"
+    network_mode: 'host'
   back-static-assets:
     build:
       context: ./static-assets/
@@ -52,8 +51,8 @@ services:
     ports:
       # Make the port availble to linked dockers but no need
       # to forward to host machine.
-      - "$ASSETS_PORT:$ASSETS_PORT"
-    mem_limit: 1000000000
-TERMINATOR
+      - '$ASSETS_PORT:$ASSETS_PORT'
+    mem_limit: 1000000000"
 
-docker-compose  -f $TEMP up --build
+cd $DOCKER_DIR
+echo "$CONFIG" | docker-compose -f - up --build

--- a/gdebug/docker/start_docker.sh
+++ b/gdebug/docker/start_docker.sh
@@ -12,12 +12,6 @@ fi
 
 readonly DOCKER_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-TEMP=$(mktemp -p $DOCKER_DIR --suffix=.yaml)
-function finish {
-  rm "$TEMP"
-}
-trap finish EXIT
-
 readonly ENVOY_PORT=$1
 readonly GRPC_ADDR=$2
 readonly GRPC_PORT=$3


### PR DESCRIPTION
mktemp works differently on osx. Pipe the config to stdin to avoid the
problem.

This supersedes https://github.com/grpc/grpc-experiments/pull/312